### PR TITLE
Scorer

### DIFF
--- a/pyt_splade/__init__.py
+++ b/pyt_splade/__init__.py
@@ -46,9 +46,9 @@ class Splade():
 
     indexing = doc_encoder  # backward compatible name
 
-    def query_encoder(self, batch_size=100, sparse=True, verbose=False, matchop=False, scale=1.) -> pt.Transformer:
+    def query_encoder(self, batch_size=100, sparse=True, verbose=False, matchop=False, scale=100) -> pt.Transformer:
         out_field = 'query_toks' if sparse else 'query_vec'
-        res = SpladeEncoder(self, 'query', out_field, 'q', sparse, batch_size, verbose)
+        res = SpladeEncoder(self, 'query', out_field, 'q', sparse, batch_size, verbose, scale)
         if matchop:
             res = res >> MatchOp()
         return res


### PR DESCRIPTION
Hi!
I am doing some experiments using pyterrier and pyt_splade following the[ terrierteam demo,](https://huggingface.co/spaces/terrierteam/splade) however, I was stuck with this:

```
15:22:36.585 [ForkJoinPool-1-worker-1] ERROR org.terrier.structures.indexing.classical.InvertedIndexBuilder - Exception occured during creating the inverted file. Stack trace follows.
java.io.EOFException: null
	at java.base/java.io.DataInputStream.readByte(DataInputStream.java:273)
	at org.terrier.compression.bit.BitInputStream.incrByte(BitInputStream.java:137)
	at org.terrier.compression.bit.BitInBase.readUnary(BitInBase.java:73)
	at org.terrier.compression.bit.BitInBase.readGamma(BitInBase.java:111)
	at org.terrier.structures.postings.bit.BasicIterablePosting.next(BasicIterablePosting.java:119)
	at org.terrier.structures.indexing.classical.InvertedIndexBuilder.traverseDirectFile(InvertedIndexBuilder.java:719)
	at org.terrier.structures.indexing.classical.InvertedIndexBuilder.createInvertedIndex(InvertedIndexBuilder.java:283)
	at org.terrier.structures.indexing.classical.BasicIndexer.createInvertedIndex(BasicIndexer.java:457)
	at org.terrier.structures.indexing.classical.BasicIndexer.indexDocuments(BasicIndexer.java:293)
	at org.terrier.python.ParallelIndexer$1.apply(ParallelIndexer.java:68)
	at org.terrier.python.ParallelIndexer$1.apply(ParallelIndexer.java:52)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1006)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:960)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:934)
	at java.base/java.util.stream.AbstractTask.compute(AbstractTask.java:327)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:667)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:927)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:662)
	at org.terrier.python.ParallelIndexer$2.call(ParallelIndexer.java:77)
	at org.terrier.python.ParallelIndexer$2.call(ParallelIndexer.java:74)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1456)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```
After some debugging, I found out that the problem starts after the implicit transformation of all the weights in integers (see [line 1028 in index.py](https://github.com/terrier-org/pyterrier/blob/master/pyterrier/index.py#L1028) in pyterrier).
Without an appropriate scaling, almost all the weights are cast into zeros, and having only one weight to 0 raises the error above in terrier.
Thus, I think it would be better to suggest (using the default parameter) to scale and cast to integers if we request the tokenization and the parameter is of type "document" (d), everything before indexing.
With these modifications, now the demo is working correctly.
I also suggest removing the mult parameter to `Matchop` and using only one parameter for scaling everything (`scale`) to avoid confusion.

I thought these changes would have been helpful to others, which is why I made the pull request. I hope they are!
